### PR TITLE
Fixed imposter number error message

### DIFF
--- a/amogus/index.html
+++ b/amogus/index.html
@@ -157,7 +157,7 @@
             <div class="form-group">
                 <label for="totalPlayers">Total Number of Players (4-20):</label>
                 <input type="number" id="totalPlayers" min="4" max="20" value="10">
-                <div id="totalError" class="error">Total players must be between 4 and 15</div>
+                <div id="totalError" class="error">Total players must be between 4 and 20</div>
             </div>
             <div class="form-group">
                 <label for="imposters">Number of Imposters (1-7):</label>


### PR DESCRIPTION
If the number of players is more than 20 it'll now tell you that you must have 4-20 players instead of 4-15.